### PR TITLE
fix issue with downgrading statuses for items with a close reason

### DIFF
--- a/app/stores/__tests__/product-store-test.js
+++ b/app/stores/__tests__/product-store-test.js
@@ -31,6 +31,32 @@ describe('ProductStore', function() {
     });
   });
 
+  describe('internals.updateItem', function() {
+    beforeEach(function() {
+      this.products = ProductStore.__get__('products');
+      this.product = this.products.add({ id: 1 });
+      this.item = this.product.items.add(
+        { id: 1, status: 'in-progress' }
+      );
+      this.item.save = sinon.stub();
+    });
+
+    afterEach(function() {
+      this.product.items.reset();
+    });
+
+    it('unsets the close reason if status is changing', function() {
+      this.item.set({ close_reason: 'fixed' });
+      ProductStore.internals.updateItem(1, 1, { status: 'current' });
+      assert.isUndefined(this.item.get('close_reason'));
+    });
+
+    it('calls item.save', function() {
+      ProductStore.internals.updateItem(1, 1, { status: 'current' });
+      sinon.assert.calledWith(this.item.save, { status: 'current' });
+    });
+  });
+
   describe('internals.loadMoreItems', function() {
     beforeEach(function() {
       this.collection = new Backbone.Collection();

--- a/app/stores/product-store.js
+++ b/app/stores/product-store.js
@@ -155,6 +155,11 @@ var internals = ProductStore.internals = {
   updateItem(productId, itemId, payload) {
     let product = products.get(productId);
     let item = product.items.get(itemId);
+
+    if (payload.status) {
+      item.unset('close_reason', { silent: true });
+    }
+
     item.save(payload);
   },
 


### PR DESCRIPTION
#### What does it do?

Fixes an API error received when sending a `close_reason` for certain status changes. For instance, if you try to move an item from Completed to Accepted, it will error because the previous `close_reason` value is sent along to the API.
#### Where should the reviewer start?

small change in `app/stores/product-store.js` and some tests
#### How should this be manually tested?

Moving items from the Completed column should persist to the API.
#### Background context?

I thought this was an API bug but it turned out to be user error.
#### GIF?

![tumblr_ml68tlx4xm1r9uuuso1_r1_500](https://cloud.githubusercontent.com/assets/84644/6957939/e6bb7ff2-d8b8-11e4-9211-67c6bdc7d80b.gif)
