### PR TITLE
5 columns viewable on smaller screen width

### DIFF
--- a/public/less/components/columns.less
+++ b/public/less/components/columns.less
@@ -135,7 +135,7 @@
   }
 }
 
-@media (min-width: 1800px) {
+@media (min-width: 1300px) {
   .tray {
     width: 100%;
     .translate(0, 0);


### PR DESCRIPTION
Lowering min-width breakpoint to 1300px for viewing all 5 columns.

Fixes #9942
https://sprint.ly/product/1/item/9942

![](http://i.giphy.com/RrVzUOXldFe8M.gif)
