### PR TITLE
Ensuring members is defined after fetch

### DIFF
--- a/app/stores/filters-store.js
+++ b/app/stores/filters-store.js
@@ -63,6 +63,7 @@ var internals = FiltersStore.internals = {
     .then(function() {
       internals.decorateMembers(members);
       internals.decorateTags(tags);
+      ProductStore.getAll();
       FiltersStore.emitChange();
     });
   },


### PR DESCRIPTION
The members assignment dropdown list was intermittently empty. That members object is defined [here](https://github.com/sprintly/5columns/blob/master/app/stores/product-store.js#L38), and if that function gets called before the fetch that happens [here](https://github.com/sprintly/5columns/blob/master/app/stores/filters-store.js#L60) - the members list is empty.

My current solution is to explicitly call `ProductStore.getAll()` after the fetch has completed to insure members is being set/re-set with an accurate list of members.

Fixes #44 - https://sprint.ly/product/31528/item/44

![](http://i.giphy.com/3oEduLZjEjvgeneZKE.gif)