### PR TITLE
#9: Search placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Run tests to run in a browser:
 
 ```bash
 $ make test-server
+$ npm run watchify-test
 ```
 
 #### npm shrinkwrap

--- a/app/stores/product-store-test.js
+++ b/app/stores/product-store-test.js
@@ -104,6 +104,57 @@ describe('ProductStore', function() {
     });
   });
 
+  describe('#hasItems', function(){
+    it('returns false when the product has no items', function() {
+      let mockProduct  = {
+        get: function(id) {
+          console.log("HERE");
+          return {items: []}
+        }
+      }
+      ProductStore.__set__('products', mockProduct);
+      let result = ProductStore.hasItems();
+
+      assert.isFalse(result)
+    })
+    it('returns true when the product has items', function() {
+      let mockProduct  = {
+        get: function(id) {
+          console.log("HERE");
+          return {items: [1,2,3]}
+        }
+      }
+      ProductStore.__set__('products', mockProduct);
+      let result = ProductStore.hasItems();
+
+      assert.isTrue(result)
+    })
+  })
+
+  describe('#hasItemsToRender', function() {
+    describe('returns true', function() {
+      it('when product collection has items', function() {
+        let mockCollection = {items: [1,2,3]};
+        this.sinon.stub(ProductStore.internals, 'itemsForProduct').returns([mockCollection]);
+
+        let result = ProductStore.hasItemsToRender(1);
+        assert.isTrue(result);
+      })
+    })
+
+    describe('returns false', function() {
+      it('when product collection has no items', function() {
+        it('when product collection has items', function() {
+          let mockCollection = {items: []};
+          this.sinon.stub(ProductStore.internals, 'itemsForProduct').returns([mockCollection]);
+
+          let result = ProductStore.hasItemsToRender(1);
+          assert.isFalse(result);
+        })
+      })
+    })
+  })
+
   xdescribe('getItemsForProduct', function() {
     it('returns an items collection', function() {
 

--- a/app/stores/product-store.js
+++ b/app/stores/product-store.js
@@ -78,20 +78,23 @@ var ProductStore = module.exports = _.assign({}, EventEmitter.prototype, {
   },
 
   hasItems(productId) {
-    let collections = internals.collectionsForProduct(productId)
-    if(collections.length > 0) {
+    return products.get(productId).items.length > 0
+  },
+
+  hasItemsToRender(productId) {
+    let collections = internals.itemsForProduct(productId)
+    if (collections.length > 0) {
       let hasItems = false;
 
       _.each(collections, (col) => {
-        if (col.models.length > 0) {
+        if(col.items.length > 0) {
           hasItems = true;
         }
-      });
+      })
 
       return hasItems;
     } else {
-      // Return true optimistically to prevent flicker of content
-      return true;
+      return false;
     }
   },
 
@@ -335,10 +338,10 @@ var internals = ProductStore.internals = {
     }
   },
 
-  collectionsForProduct(productId) {
+  itemsForProduct(productId) {
     return _.chain(ITEM_STATUSES)
             .map((status) => {
-              return ProductStore.getItemsCollection(productId, status);
+              return ProductStore.getItems(productId, status);
             })
             .compact()
             .value()

--- a/app/views/components/item-column/index-test.js
+++ b/app/views/components/item-column/index-test.js
@@ -17,8 +17,8 @@ describe('Item Column', function() {
   beforeEach(function() {
     this.sinon = sinon.sandbox.create();
     this.ProductStore = ItemColumn.__get__('ProductStore');
-    this.ProductActions = ItemColumn.__get__('ProductActions');
     this.getItemsStub = this.sinon.stub(this.ProductStore, 'getItems');
+    this.ProductActions = ItemColumn.__get__('ProductActions');
     this.getItemsForProductStub = this.sinon.stub(this.ProductActions, 'getItemsForProduct');
     this.props = {
       filters: {},
@@ -35,6 +35,9 @@ describe('Item Column', function() {
   });
 
   describe('renderSprints', function() {
+    beforeEach(function() {
+      this.hasItems = this.sinon.stub(this.ProductStore, 'hasItems');
+    });
 
     context('not in-progress', function() {
       beforeEach(function() {
@@ -66,6 +69,7 @@ describe('Item Column', function() {
           sortField: 'last_updated',
           isLoading: false
         });
+
         let itemSummary = TestUtils.scryRenderedDOMComponentsWithClass(
           this.component.refs.stub,
           'item__summary'
@@ -74,4 +78,90 @@ describe('Item Column', function() {
       });
     });
   });
+
+  describe('#renderItemCards', function() {
+    beforeEach(function() {
+      this.props.status = 'backlog';
+      this.component = renderComponent(this.props, this);
+    });
+
+    it('renders item cards', function() {
+      this.sinon.stub(this.ProductStore, 'hasItems').returns(true);
+      this.sinon.stub(this.ProductStore, 'hasItemsToRender').returns(true);
+
+      this.component.refs.stub.setState({
+        items: [{}],
+        isLoading: false
+      });
+
+      let itemCards = TestUtils.scryRenderedDOMComponentsWithClass(
+        this.component.refs.stub,
+        'item-card'
+      );
+
+      assert.lengthOf(itemCards, 1);
+    })
+
+    describe('NoSearchResults', function() {
+      beforeEach(function() {
+        this.sinon.stub(this.ProductStore, 'hasItems').returns(true);
+        this.sinon.stub(this.ProductStore, 'hasItemsToRender').returns(false);
+      })
+
+      it('renders NoSearchResults for \'in-progress\' status', function() {
+        let props = {status: 'in-progress', product:{id:0}};
+        let Component = stubRouterContext(ItemColumn, props);
+        let columnComponent = TestUtils.renderIntoDocument(<Component {...props}/>);
+
+        columnComponent.refs.stub.setState({
+          items: [],
+          isLoading: false
+        });
+
+        let noSearchResults = TestUtils.scryRenderedDOMComponentsWithClass(
+          columnComponent.refs.stub,
+          'no-search-results'
+        );
+
+        assert.lengthOf(noSearchResults, 1);
+      })
+
+      it('renders nothing for non \'in-progress\'', function() {
+        this.component.refs.stub.setState({
+          status: 'backlog',
+          items: [{}],
+          isLoading: false
+        });
+
+        let noSearchResults = TestUtils.scryRenderedDOMComponentsWithClass(
+          this.component.refs.stub,
+          'no-search-results'
+        );
+
+        assert.lengthOf(noSearchResults, 0);
+      })
+    })
+
+    it('renders PlaceholderCards', function() {
+      this.sinon.stub(this.ProductStore, 'hasItems').returns(false);
+      this.sinon.stub(this.ProductStore, 'hasItemsToRender').returns(false);
+
+      let props = {status: 'in-progress', product:{id:0}};
+      let Component = stubRouterContext(ItemColumn, props);
+      let columnComponent = TestUtils.renderIntoDocument(<Component {...props}/>);
+
+      columnComponent.refs.stub.setState({
+        status: 'backlog',
+        items: [{}],
+        isLoading: false
+      })
+
+      let placeholderCards = TestUtils.scryRenderedDOMComponentsWithClass(
+        columnComponent.refs.stub,
+        'placeholder-cards'
+      );
+
+      assert.lengthOf(placeholderCards, 1);
+    })
+  })
 });

--- a/app/views/components/item-column/index.js
+++ b/app/views/components/item-column/index.js
@@ -8,6 +8,7 @@ import PlaceholderCards from './placeholder-cards'
 import SprintGroup from './sprint-group';
 import ColumnSummary from './summary';
 import ColumnHeader from './header';
+import NoSearchResults from './no-search-results';
 // Flux
 import ProductStore from '../../../stores/product-store';
 import ProductActions from '../../../actions/product-actions';
@@ -29,7 +30,10 @@ var ItemColumn = React.createClass({
   propTypes: {
     status: React.PropTypes.string.isRequired,
     product: React.PropTypes.object.isRequired,
-    productHasItems: React.PropTypes.bool.isRequired
+    members: React.PropTypes.array.isRequired,
+    filters: React.PropTypes.object.isRequired,
+    key: React.PropTypes.string.isRequired,
+    velocity: React.PropTypes.object.isRequired
   },
 
   getInitialState() {
@@ -106,11 +110,24 @@ var ItemColumn = React.createClass({
     )
   },
 
-  renderItemCards() {
-    if (this.props.productHasItems) {
-      let itemCards = _.map(this.state.items, this.renderItemCard)
+  productHasItemsToRender() {
+    return ProductStore.hasItemsToRender(this.props.product.id);
+  },
 
-      return <div>{itemCards}</div>
+  productHasItems() {
+    return ProductStore.hasItems(this.props.product.id)
+  },
+
+  renderItemCards() {
+    if (this.productHasItems()) {
+      if (this.productHasItemsToRender()) {
+        let itemCards = _.map(this.state.items, this.renderItemCard)
+        return <div>{itemCards}</div>
+      } else if (this.props.status === 'in-progress') {
+        return <NoSearchResults />;
+      } else {
+        return '';
+      }
     } else {
       return <PlaceholderCards status={this.props.status} />
     }

--- a/app/views/components/item-column/index.js
+++ b/app/views/components/item-column/index.js
@@ -110,18 +110,20 @@ var ItemColumn = React.createClass({
     )
   },
 
-  productHasItemsToRender() {
-    return ProductStore.hasItemsToRender(this.props.product.id);
+  productHasItems() {
+    console.log(ProductStore)
+    return ProductStore.hasItems(this.props.product.id)
   },
 
-  productHasItems() {
-    return ProductStore.hasItems(this.props.product.id)
+  productHasItemsToRender() {
+    return ProductStore.hasItemsToRender(this.props.product.id);
   },
 
   renderItemCards() {
     if (this.productHasItems()) {
       if (this.productHasItemsToRender()) {
         let itemCards = _.map(this.state.items, this.renderItemCard)
+
         return <div>{itemCards}</div>
       } else if (this.props.status === 'in-progress') {
         return <NoSearchResults />;

--- a/app/views/components/item-column/no-search-results.js
+++ b/app/views/components/item-column/no-search-results.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+var NoSearchResults = React.createClass({
+  clearFilters() {
+    console.log('Clear Filters Dependant on Mobile Nav Land');
+  },
+
+  render() {
+    return (
+      <div className='no-search-results'>
+        <div className="content">
+          <div className="row">
+            <div className="col-sm-12">
+              <h1>No Results!</h1>
+              <h5>Try filtering again or reset your filters.</h5>
+            </div>
+            <div className="item-card__title col-sm-12">
+              <button style={ {width: "100%"} } className="btn btn-primary" onClick={this.clearFilters}>Clear Filters</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+})
+
+module.exports = NoSearchResults;

--- a/app/views/pages/items-test.js
+++ b/app/views/pages/items-test.js
@@ -11,6 +11,10 @@ describe('Items ViewController', function() {
     this.sinon = sinon.sandbox.create();
     this.ProductActions = Items.__get__('ProductActions');
     this.productInitStub = this.sinon.stub(this.ProductActions, 'init');
+
+    this.ProductStore = Items.__get__('ProductStore');
+    this.sinon.stub(this.ProductStore, 'getProduct');
+    this.sinon.stub(this.ProductStore, 'getAll');
   });
 
   afterEach(function() {
@@ -18,8 +22,9 @@ describe('Items ViewController', function() {
   });
 
   it('initializes the current product on mount', function() {
-    var ItemsStub = stubRouterContext(Items, { user: { get: function() {} } }, {
-      getCurrentParams: ()=> {
+    let user = { user: { get: function() {} } }
+    var ItemsStub = stubRouterContext(Items, user, {
+      getCurrentParams: () => {
         return { id: 1 }
       }
     });

--- a/app/views/pages/items.js
+++ b/app/views/pages/items.js
@@ -72,8 +72,7 @@ module.exports = React.createClass({
       members: this.state.members,
       filters: this.state.filtersObject,
       key: `col-${this.state.product.id}-${status}`,
-      velocity: this.state.velocity,
-      productHasItems: ProductStore.hasItems(this.state.product.id)
+      velocity: this.state.velocity
     };
 
     return <ItemColumn {...props} />;

--- a/app/views/pages/items.js
+++ b/app/views/pages/items.js
@@ -40,6 +40,7 @@ module.exports = React.createClass({
   },
 
   _onChange: function() {
+    console.log()
     var product = ProductStore.getProduct(this.getParams().id) || {};
     this.setState(_.assign({
       allFilters: FiltersStore.all(),

--- a/app/views/pages/search-test.js
+++ b/app/views/pages/search-test.js
@@ -35,6 +35,7 @@ describe('Search ViewController', function() {
     this.sinon = sinon.sandbox.create();
     this.ProductActions = Search.__get__('ProductActions');
     this.ProductStore = Search.__get__('ProductStore');
+    this.sinon.stub(this.ProductStore, 'getAll');
     this.SearchActions = Search.__get__('SearchActions');
     this.SearchStore = Search.__get__('SearchStore');
 

--- a/public/less/components/no-search-results.less
+++ b/public/less/components/no-search-results.less
@@ -1,0 +1,11 @@
+.no-search-results {
+  text-align: center;
+  margin-top: 100%;
+}
+
+.no-search-results .content {
+  height: 100px;
+
+  button {
+  }
+}

--- a/public/less/main.less
+++ b/public/less/main.less
@@ -34,4 +34,5 @@ html, body {
 @import "components/add-item-modal";
 @import "components/tags-input";
 @import "components/placeholder-cards";
+@import "components/no-search-results";
 @import "overrides";


### PR DESCRIPTION
#### What's this PR do?
Fixes the placeholder cards from being rendered on a search filter that returns no results.

Checks the `sprintly-client` product for items instead of the Product Store collections

Bonus: Renders a message when there are no search results.

#### Where should the reviewer start?
`app/views/components/item-column/index.js` holds the conditional logic to

* render item cards
* render placeholder cards
* render no results prompt

#### How should this be manually tested?
Create a filter on a product which has no results

#### Any background context you want to provide?
A clear filters action will land with the mobile navigation PR

#### What are the relevant tickets?
#97 https://sprint.ly/product/31528/item/97

#### Screenshots (if appropriate)
![image](https://cloud.githubusercontent.com/assets/2892213/8265351/21f42fba-16ad-11e5-89a8-c956b4a5a4d0.png)