### PR TITLE
#36-kanban add item description resizable

### DIFF
--- a/public/less/components/add-item-modal.less
+++ b/public/less/components/add-item-modal.less
@@ -211,7 +211,6 @@
         position: relative;
         outline: 0;
         overflow: hidden;
-        resize: none;
       }
 
       .highlighter {
@@ -236,10 +235,6 @@
         color: #444;
       }
     }
-  }
-
-  textarea {
-    resize: none;
   }
 
   .suggestions {
@@ -344,4 +339,3 @@
     font-size: 15px;
   }
 }
-


### PR DESCRIPTION
#### What's this PR do?
Removes the resize:none restriction on AddItemModal

#### How should this be manually tested?
* Run the app
* Click add item modal and resize the description

#### What are the relevant tickets?
`#36`

#### Screenshots (if appropriate)
http://g.recordit.co/1otsXozb1s.gif