### PR TITLE
#135-mobile-breakpoints

### DIFF
--- a/app/views/components/item-column/index.js
+++ b/app/views/components/item-column/index.js
@@ -34,7 +34,7 @@ var ItemColumn = React.createClass({
     filters: React.PropTypes.object.isRequired,
     key: React.PropTypes.string.isRequired,
     velocity: React.PropTypes.object.isRequired,
-    maxWidth: React.PropTypes.object
+    colWidth: React.PropTypes.object
   },
 
   getInitialState() {
@@ -195,9 +195,8 @@ var ItemColumn = React.createClass({
       this.setSortCriteria(this.state.sortField, direction);
     };
 
-
     return (
-      <div style={this.props.maxWidth} className={React.addons.classSet(classes)} {...this.props}>
+      <div style={this.props.colWidth} className={React.addons.classSet(classes)} {...this.props}>
         <ColumnHeader {...this.props}
           reverse={reverseSort}
           setSortCriteria={this.setSortCriteria}

--- a/app/views/pages/items.js
+++ b/app/views/pages/items.js
@@ -64,7 +64,8 @@ module.exports = React.createClass({
 
     if (helpers.isMobile(window)) {
       this.setState({
-        maxWidth: {'max-width': `${window.innerWidth * this.colCount()}px`}
+        trayWidth: {'width': `${window.innerWidth * this.colCount()}px`},
+        colWidth: {'width': `${window.innerWidth}px`}
       })
     }
   },
@@ -85,13 +86,9 @@ module.exports = React.createClass({
       members: this.state.members,
       filters: this.state.filtersObject,
       key: `col-${this.state.product.id}-${status}`,
-      velocity: this.state.velocity
+      velocity: this.state.velocity,
+      colWidth: this.state.colWidth
     };
-
-    if (this.state.maxWidth) {
-      var maxColWidth = {'max-width': `${window.innerWidth}px`};
-      _.assign(props, maxColWidth);
-    }
 
     return <ItemColumn {...props} />;
   },
@@ -119,7 +116,7 @@ module.exports = React.createClass({
       }
 
       return (
-          <nav style={this.state.maxWidth} key={`header-nav-${status}`}>
+          <nav style={this.state.colWidth} key={`header-nav-${status}`}>
             <button type="button" onClick={_.partial(this.translateColumns, 'previous')} className={`visible-xs btn previous${prevClasses}`}>
               <span className="glyphicon glyphicon-chevron-left"></span>
             </button>
@@ -150,8 +147,7 @@ module.exports = React.createClass({
 
   trayStyles() {
     var transform = helpers.browserPrefix('transform', `translateX(${this.state.translation.value})`)
-    var maxCopy = _.cloneDeep(this.state.maxWidth);
-    return _.merge(maxCopy, transform);
+    return _.merge(this.state.trayWidth, transform);
   },
 
   componentWillReceiveProps: function(nextProps) {


### PR DESCRIPTION
#### What's this PR do?
Uses width `attr` instead of `max-width` for the dynamic tray and column sizes on mobile.

#### How should this be manually tested?
Load the app on an iPhone 6+ and see each column occupy the full width of the page

#### What are the relevant tickets?
[#135](https://sprint.ly/product/31528/item/135)

#### Screenshots (if appropriate)
![iphone6](http://g.recordit.co/9KwcQGJ74z.gif)