### PR TITLE
151 kanban search header

### DIFF
--- a/app/views/components/header-test.js
+++ b/app/views/components/header-test.js
@@ -32,6 +32,26 @@ describe('Header', function() {
     it('renders the header component', function () {
       assert.isTrue(TestUtils.isCompositeComponentWithType(this.component.refs.stub, Header));
     });
+
+    describe('header bar components', function() {
+      beforeEach(function() {
+        this.headers = TestUtils.scryRenderedDOMComponentsWithTag(this.component.refs.stub, 'header');
+      })
+
+      it('renders two', function() {
+        assert.lengthOf(this.headers, 2)
+      })
+
+      it('one header is visible for small screens', function() {
+        let mobileHeader = this.headers[0].getDOMNode();
+        assert.isTrue(mobileHeader.classList.contains('visible-xs'));
+      })
+
+      it('one header is visible for larger screens', function() {
+        let mobileHeader = this.headers[1].getDOMNode()
+        assert.isTrue(mobileHeader.classList.contains('hidden-xs'));
+      })
+    })
   });
 
   describe('click on \'Add Item\'', function () {

--- a/app/views/components/header.js
+++ b/app/views/components/header.js
@@ -104,17 +104,25 @@ var Header = React.createClass({
     let openRightSide = _.partial(SidebarActions.show, 'right');
     let openLeftSide = _.partial(SidebarActions.show, 'left');
 
-    let isProductSelectPage = this.getPathname() === '/';
+    let hideRightMenuTrigger = this.getPathname() === '/' || this.getPathname() === '/search';
     let filterClasses = React.addons.classSet({
       'btn filter-icon': true,
-      'hidden': isProductSelectPage
+      'hidden': hideRightMenuTrigger
     });
+    let hideLeftMenuTrigger = this.getPathname() === '/';
     let menuClasses = React.addons.classSet({
       "small-menu": true,
-      'hidden': isProductSelectPage
+      'hidden': hideLeftMenuTrigger
     });
 
-    let searchBarStyle = isProductSelectPage ? {width: '100%'} : {width: '70%'};
+    let searchBarStyle;
+    if (hideLeftMenuTrigger && hideRightMenuTrigger) {
+      searchBarStyle = {width: '100%'};
+    } else if (hideRightMenuTrigger) {
+      searchBarStyle = {width: '85%'};
+    } else {
+      searchBarStyle = {width: '70%'};
+    }
 
     return (
       <header className={navClasses}>

--- a/app/views/components/header.js
+++ b/app/views/components/header.js
@@ -79,15 +79,20 @@ var Header = React.createClass({
     return '';
   },
 
-  renderSearch() {
+  getScope() {
     let scope = '';
     if (this.props.product.id && this.state.scoped) {
       scope = <span className="header-search__scope label label-info">{this.props.product.name}</span>
     }
+
+    return scope;
+  },
+
+  renderSearch() {
     return (
       <form className="navbar-form navbar-right header-search" onSubmit={this.search} role="search">
         <div className="form-group">
-          {scope}
+          {this.getScope()}
           <input className="form-control" type="search" name="q" placeholder="Search" ref="search" onKeyDown={this.onKeyDown} />
         </div>
         <input type="submit" className="hidden" />
@@ -132,7 +137,8 @@ var Header = React.createClass({
         <div style={searchBarStyle} className="mobile-search">
           <form className="navbar-right header-search" onSubmit={this.search} role="search">
             <div className="form-group">
-                <input className="form-control" type="search" name="q" placeholder="Search" ref="search" onKeyDown={this.onKeyDown} />
+              {this.getScope()}
+              <input className="form-control" type="search" name="q" placeholder="Search" ref="search" onKeyDown={this.onKeyDown} />
             </div>
             <input type="submit" className="hidden" />
           </form>

--- a/app/views/components/sidebars/search.js
+++ b/app/views/components/sidebars/search.js
@@ -3,7 +3,7 @@ import React from 'react/addons';
 let SearchSidebar = React.createClass({
   render() {
     return (
-      <h1>SerachSidebar</h1>
+      <div></div>
     )
   }
 })

--- a/app/views/pages/search.js
+++ b/app/views/pages/search.js
@@ -374,7 +374,7 @@ var Search = React.createClass({
 
   render() {
     return (
-      <div>
+      <div className="container-tray">
         <Header
           searchBar={false}
           user={this.props.user}

--- a/public/less/components/search.less
+++ b/public/less/components/search.less
@@ -37,6 +37,9 @@
     border: none;
     color: #fff;
     .box-shadow(none);
+    display: inline-block;
+    width: auto;
+    vertical-align: middle;
   }
 
   .btn-default {


### PR DESCRIPTION
#### What's this PR do?
Fixes these styling issues:

* Page-Search: search sidebar mobile tray was visible on screen size > xs
* Page-Search: mobile nav search drawer button trigger visible
* Component-SearchBar: the scope was not present in the searchbar on mobile

Also added simple class and presence test coverage on the header elements

#### What are the relevant tickets?
[151](https://sprint.ly/product/31528/item/151)

#### Screenshots (if appropriate)
![before](https://cloud.githubusercontent.com/assets/2892213/8416862/72777c64-1e5d-11e5-939b-222e5db1baed.png)
![after](https://cloud.githubusercontent.com/assets/2892213/8416871/7d1866ce-1e5d-11e5-8c82-871f8386f8c9.png)
