### PR TITLE
Fix Console Warnings

### DIFF
--- a/app/views/app.js
+++ b/app/views/app.js
@@ -22,7 +22,7 @@ export default React.createClass({
   },
 
   render: function() {
-    let style = {'min-height': `${window.innerHeight}px`};
+    let style = { minHeight: `${window.innerHeight}px`};
 
     let touchEndFn = helpers.isMobile(window) ? this.muteDoubleTap : function() {};
 

--- a/app/views/components/filters/sidebar-filters.js
+++ b/app/views/components/filters/sidebar-filters.js
@@ -50,10 +50,10 @@ var SidebarFilters = React.createClass({
     }
 
     return ([
-      <li className="drawer-header">
+      <li className="drawer-header" key="drawer-header">
         <a className='drawer-header' href="#">Tags</a>
       </li>,
-      <li className="drawer-subheader">
+      <li className="drawer-subheader" key="drawer-subheader">
         <div className="form-group">
           <TagsInput tags={tags} onChange={this.addTags} value={activeTags}/>
         </div>

--- a/app/views/components/header.js
+++ b/app/views/components/header.js
@@ -15,7 +15,7 @@ const ACCOUNT_SETTINGS = [
   'Profile', 'Plan', 'Billing', 'Invoices', 'Products', 'Members', 'Notifications', 'Services'
 ];
 
-var Header = React.createClass({
+let KanbanHeader = React.createClass({
 
   mixins: [State, Navigation],
 
@@ -177,7 +177,7 @@ var Header = React.createClass({
 
   logoutLink() {
     return (
-      <li className="logout">
+      <li className="logout" key="logout">
         <a href="https://sprint.ly/logout" className="btn btn-danger btn-sm btn-block">Logout</a>
       </li>
     )
@@ -257,4 +257,4 @@ var Header = React.createClass({
   },
 });
 
-export default Header;
+export default KanbanHeader;

--- a/app/views/components/item-column/header.js
+++ b/app/views/components/item-column/header.js
@@ -8,7 +8,7 @@ const SORT_OPTIONS = {
   last_modified: 'Recent'
 };
 
-var Header = React.createClass({
+let ColumnHeader = React.createClass({
 
   getDefaultProps: function() {
     return {
@@ -59,4 +59,4 @@ var Header = React.createClass({
   }
 })
 
-module.exports = Header
+export default ColumnHeader

--- a/app/views/components/item-column/index.js
+++ b/app/views/components/item-column/index.js
@@ -32,7 +32,6 @@ var ItemColumn = React.createClass({
     product: React.PropTypes.object.isRequired,
     members: React.PropTypes.array.isRequired,
     filters: React.PropTypes.object.isRequired,
-    key: React.PropTypes.string.isRequired,
     velocity: React.PropTypes.object.isRequired,
     colWidth: React.PropTypes.object
   },

--- a/app/views/components/item-column/placeholder-cards.js
+++ b/app/views/components/item-column/placeholder-cards.js
@@ -20,14 +20,14 @@ var PlaceholderCards = React.createClass({
     return _.times(length, (n) => {
       var width = (n === length-1) ? Math.floor((Math.random() * (100 - 50) + 50)) : 100;
 
-      return <div style={ {width: `${width}%`} } className="ipsum-block"></div>
+      return <div style={ {width: `${width}%`} } className="ipsum-block" key={n}></div>
     })
   },
 
   actionContent() {
     return ([
-        <div className="prompt__create-item">Add an Item to get started!</div>,
-        <button style={ {width: "100%"} } className="btn btn-primary" onClick={this.triggerModal}>Add an Item</button>
+        <div className="prompt__create-item" key="add-item-label">Add an Item to get started!</div>,
+        <button style={ {width: "100%"} }  key="add-item-button" className="btn btn-primary" onClick={this.triggerModal}>Add an Item</button>
       ]
     )
   },
@@ -46,7 +46,7 @@ var PlaceholderCards = React.createClass({
       }
 
       return (
-        <div className="item-card placeholder">
+        <div className="item-card placeholder" key={n}>
           <div className="row">
             <div className="item-card__header col-sm-12">
               <div className="item-card__header-right">

--- a/app/views/components/sidebar.js
+++ b/app/views/components/sidebar.js
@@ -89,11 +89,11 @@ let Sidebar = React.createClass({
     })
 
     return ([
-        <li className="drawer-header">
+        <li className="drawer-header" key="drawer-header">
           <a className='drawer-header' href="#">Settings</a>
         </li>
       ].concat(settingsLinks).concat([
-        <li className="logout">
+        <li className="logout" key="logout">
           <a href="/logout" className="btn btn-danger btn-sm btn-block">Logout</a>
         </li>
       ])
@@ -114,7 +114,7 @@ let Sidebar = React.createClass({
     })
 
     return ([
-      <li className="drawer-header">
+      <li className="drawer-header" key="drawer-header">
         <a className={'drawer-header'} href="#">Products</a>
       </li>
     ].concat(productLinks))

--- a/app/views/components/sidebars/filters.js
+++ b/app/views/components/sidebars/filters.js
@@ -17,12 +17,6 @@ let FiltersSidebar = React.createClass({
     activeFilters: React.PropTypes.array.isRequired
   },
 
-  // getInitialState: function() {
-  //   return {
-  //     mine: { active: false }
-  //   };
-  // },
-
   toggleControlState(controls, value) {
     controls[value] = (controls[value]) ? false : true;
     this.setState(controls);
@@ -48,7 +42,7 @@ let FiltersSidebar = React.createClass({
     let issueTypes = ['story', 'task', 'test', 'defect'];
     let activeTypes = _.find(this.props.activeFilters, {field: 'type'}).criteria;
 
-    let issueTypeButtons = _.map(issueTypes, (type) => {
+    let issueTypeButtons = _.map(issueTypes, (type, i) => {
       let typeClass = {}
       typeClass[type] = true;
 
@@ -63,7 +57,7 @@ let FiltersSidebar = React.createClass({
       })
 
       return (
-        <div className='issue-control' onClick={_.partial(this.updateItemTypes, type)}>
+        <div className='issue-control' onClick={_.partial(this.updateItemTypes, type)} key={i}>
           <a ref={`issue-link-${type}`} href="#" className={linkClasses}>{type}</a>
           <div className={`${colorIndicator} ${type}`}></div>
         </div>
@@ -76,10 +70,10 @@ let FiltersSidebar = React.createClass({
     });
 
     return ([
-      <li className="drawer-header">
+      <li className="drawer-header" key="drawer-header">
         <a className='drawer-header' href="#">Issue Types</a>
       </li>,
-      <li className="drawer-subheader">
+      <li className="drawer-subheader" key="drawer-subheader">
         <div className="issue-types-control">
           {issueTypeButtons}
         </div>
@@ -141,7 +135,7 @@ let FiltersSidebar = React.createClass({
       'sidebar-offcanvas': true,
       'visible-xs': true
     })
-    var maxHeight = { 'max-height': `${window.innerHeight}px` };
+    var maxHeight = { maxHeight: `${window.innerHeight}px` };
     var mineButton = this.mineButton();
 
     return (

--- a/app/views/components/sidebars/menu.js
+++ b/app/views/components/sidebars/menu.js
@@ -51,14 +51,14 @@ let MenuSidebar = React.createClass({
 
     let productLinks = this.productLinks();
     let settingsLinks = this.settingsLinks();
-    var maxHeight = { 'max-height': `${window.innerHeight}px` };
+    let menuContent = productLinks.concat(settingsLinks);
+    let maxHeight = { maxHeight: `${window.innerHeight}px` };
 
     return (
       <div style={maxHeight} className={classes}>
         <div className="logos__sprintly"></div>
         <ul className="off-canvas-list">
-          {productLinks}
-          {settingsLinks}
+          {menuContent}
         </ul>
       </div>
     )
@@ -77,7 +77,7 @@ let MenuSidebar = React.createClass({
     })
 
     return ([
-        <li className="drawer-header">
+        <li className="drawer-header" key="settings-drawer-header">
           <a className='drawer-header' href="#">Settings</a>
         </li>
       ].concat(settingsLinks).concat([this.logoutSection()])
@@ -90,7 +90,7 @@ let MenuSidebar = React.createClass({
     let name = `${user.get('first_name')} ${user.get('last_name')}`;
 
     return (
-      <li className="logout">
+      <li className="logout" key="logout-button">
         <div className="profile">
           <div className='gravatar'>
             <Gravatar email={email} className="img-rounded" size={40} />
@@ -117,7 +117,7 @@ let MenuSidebar = React.createClass({
     })
 
     return ([
-      <li className="drawer-header">
+      <li className="drawer-header" key="products-drawer-header">
         <a className={'drawer-header'} href="#">Products</a>
       </li>
     ].concat(productLinks))

--- a/app/views/pages/items.js
+++ b/app/views/pages/items.js
@@ -25,7 +25,7 @@ const ITEM_STATUSES = {
   accepted: 'Accepted'
 };
 
-module.exports = React.createClass({
+let ItemsViewController = React.createClass({
 
   mixins: [State],
 
@@ -161,12 +161,6 @@ module.exports = React.createClass({
       return this.loadingColumn();
     }
 
-    var cols = _.map(ITEM_STATUSES, this.renderColumn);
-
-    var trayClasses = React.addons.classSet({
-      tray: true
-    });
-
     var velocity =  this.state.velocity && this.state.velocity.average ?
       this.state.velocity.average : '~';
 
@@ -190,13 +184,15 @@ module.exports = React.createClass({
           velocity={velocity}
           productId={this.state.product.id}
         />
-        <div style={trayStyles} className={trayClasses}>
+        <div style={trayStyles} className="tray">
           <div className="column__nav">
             {colHeaders}
           </div>
-          {cols}
+          {_.map(ITEM_STATUSES, this.renderColumn)}
         </div>
       </div>
     );
   }
 });
+
+export default ItemsViewController;


### PR DESCRIPTION
### What does it do?
Adds a bunch of missing `key` properties that were surfacing as console warnings.

### Where should the reviewer start?
This was mostly in the mobile menu code that landed last week; a couple of spots were using `[].concat` to assemble content for components, but didn't provide `key` props for everything.

### Background context
Even when you're outside of a loop, apparently you *must* key array properties.

There's also a need to share / reuse some of this code, but that can get addressed another day.