### PR TITLE
Added hidden-xs to left column

### DIFF
--- a/app/views/pages/product-selector.js
+++ b/app/views/pages/product-selector.js
@@ -41,7 +41,7 @@ export default React.createClass({
           allProducts={this.state.products}
         />
         <div className="container product-selector">
-          <div className="col-sm-6 product__tout">
+          <div className="col-sm-6 product__tout hidden-xs">
             <img src="https://sprintly-wasatch.global.ssl.fastly.net/4957/static/images/briefcase.png"/>
             <h1>Sprintly Kanban Board</h1>
           </div>


### PR DESCRIPTION
#### What's this PR do?

Hides the left column (briefcase logo and title) on small mobile devices (otherwise the product selector column on the right is hidden below the fold).

#### How should this be manually tested?

On desktop: should render with two columns (title + briefcase on left, product selector on right)
On mobile: should render as a single column, with just the product selector visible.

#### Any background context you want to provide?

As discussed in yesterday's stand-up with @phoenixbox 

#### What are the relevant tickets?

Fixes #194 

#### Screenshots (if appropriate)

![product-select](https://cloud.githubusercontent.com/assets/1250335/8730945/f3be8148-2ba8-11e5-9813-a6b9d0042ede.gif)

#### What gif best describes this PR or how it makes you feel?

![image](https://cloud.githubusercontent.com/assets/1250335/8730958/0418ed62-2ba9-11e5-8927-1cce7cb86fba.png)

#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
- [ ] Does the [knowledge base](https://sprint.ly/docs) need to be updated?
- [ ] Does this add new dependencies? If so, does Chef, M4, or PIP requirements need to be updated?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Are any new services fully automated in Chef?
- [ ] Are there ChefSpec tests for the new Chef recipes/cookbooks?
- [ ] Does this PR require new Mixpanel or GA events?
- [ ] Is there appropriate logging included?
