### PR TITLE
Add item fixes

### DIFF
--- a/app/views/components/add-item-modal.js
+++ b/app/views/components/add-item-modal.js
@@ -8,7 +8,6 @@ import StoryTitle from './add-item/story-title';
 import MembersDropdown from './add-item/members-dropdown';
 import IssueTemplates from './add-item/issue-templates';
 import Select from 'react-select';
-import LocalStorageMixin from 'react-localstorage';
 
 import ItemActions from '../../actions/item-actions';
 import helpers from './helpers';
@@ -31,8 +30,7 @@ let AddItemModal = React.createClass({
   },
 
   mixins: [
-    React.addons.LinkedStateMixin,
-    LocalStorageMixin
+    React.addons.LinkedStateMixin
   ],
 
   getInitialState() {
@@ -85,10 +83,14 @@ let AddItemModal = React.createClass({
 
     this.setState({ type: type }, () => {
       // ensure focus follows tabbing through types
-      let ref = type === 'story' ? this.refs.title.refs.whoInput :
+      this.setFocus(type);
+    });
+  },
+
+  setFocus(itemType) {
+    let ref = itemType === 'story' ? this.refs.title.refs.whoInput :
         this.refs.title.refs.titleInput;
       React.findDOMNode(ref).focus();
-    });
   },
 
   dismiss(ev) {
@@ -96,7 +98,15 @@ let AddItemModal = React.createClass({
     this.props.onHide();
   },
 
-  createItem(ev) {
+  onKeyDown(ev) {
+    let charCode = (typeof ev.which === "number") ? ev.which : ev.keyCode;
+    if ((ev.metaKey || ev.ctrlKey) && (charCode === 13 || charCode === 10)) {
+      this.createItem(ev, false);
+    }
+    return;
+  },
+
+  createItem(ev, closeModal=true) {
     ev.preventDefault();
     let item = _.pick(this.state, ['type', 'description', 'tags', 'assigned_to']);
 
@@ -110,22 +120,28 @@ let AddItemModal = React.createClass({
       item.status = 'backlog';
     }
 
-    ItemActions.addItem(this.props.product.id, item).then( (err) => {
-      if (!err) {
-        this.setState(this.getInitialState());
+    ItemActions.addItem(this.props.product.id, item).then( (resp) => {
+      let resetState = closeModal ? this.getInitialState() :
+        _.extend({}, this.getInitialState(), {type: this.state.type});
+
+      this.setState(resetState);
+      this.setFocus(this.state.type);
+
+      if (closeModal) {
         this.props.onHide();
-      } else {
-        this.updateValidation(err)
       }
+    }, (err) => {
+      this.updateValidation(err);
     });
   },
 
   updateValidation(err) {
     let validationState = this.state.validation;
+    let errors = err.validationError.split(':')[1].replace(/\s+/g, '').split(',');
 
-    _.each(err.validationError, (attr) => {
+    _.each(errors, (attr) => {
       validationState[attr] = false;
-    })
+    });
 
     this.setState({validation: validationState});
   },
@@ -192,7 +208,7 @@ let AddItemModal = React.createClass({
           })}
         </Nav>
         <div className='modal-body'>
-          <form onSubmit={this.createItem}>
+          <form onSubmit={this.createItem} onKeyDown={this.onKeyDown}>
             {title}
             <div className="form-group">
               <MentionsInput

--- a/app/views/components/add-item-modal.js
+++ b/app/views/components/add-item-modal.js
@@ -83,7 +83,12 @@ let AddItemModal = React.createClass({
     var descriptionTemplate = (type === 'defect') ? IssueTemplates.defect : '';
     this.setDescription(null, descriptionTemplate);
 
-    this.setState({ type: type });
+    this.setState({ type: type }, () => {
+      // ensure focus follows tabbing through types
+      let ref = type === 'story' ? this.refs.title.refs.whoInput :
+        this.refs.title.refs.titleInput;
+      React.findDOMNode(ref).focus();
+    });
   },
 
   dismiss(ev) {
@@ -158,6 +163,7 @@ let AddItemModal = React.createClass({
     if (this.state.type === 'story') {
       title = (
         <StoryTitle
+          ref="title"
           who={this.linkState('who')}
           what={this.linkState('what')}
           why={this.linkState('why')}
@@ -167,6 +173,7 @@ let AddItemModal = React.createClass({
     } else {
       title = (
         <Title
+          ref="title"
           title={this.linkState('title')}
           validation={this.linkState('validation')}
         />

--- a/app/views/components/add-item-modal.js
+++ b/app/views/components/add-item-modal.js
@@ -108,6 +108,7 @@ let AddItemModal = React.createClass({
 
   createItem(ev, closeModal=true) {
     ev.preventDefault();
+
     let item = _.pick(this.state, ['type', 'description', 'tags', 'assigned_to']);
 
     if (this.state.type === 'story') {
@@ -120,9 +121,9 @@ let AddItemModal = React.createClass({
       item.status = 'backlog';
     }
 
-    ItemActions.addItem(this.props.product.id, item).then( (resp) => {
+    ItemActions.addItem(this.props.product.id, item).then( () => {
       let resetState = closeModal ? this.getInitialState() :
-        _.extend({}, this.getInitialState(), {type: this.state.type});
+        _.extend({}, this.getInitialState(), { type: this.state.type });
 
       this.setState(resetState);
       this.setFocus(this.state.type);

--- a/app/views/components/add-item/story-title.js
+++ b/app/views/components/add-item/story-title.js
@@ -31,6 +31,10 @@ let AddItemStoryTitle = React.createClass({
     validation: React.PropTypes.object.isRequired
   },
 
+  componentDidMount() {
+    React.findDOMNode(this.refs.whoInput).focus();
+  },
+
   titleNodes() {
     return _.map(STORY_ATTRS, (attr, i) => {
       var classes = classNames({
@@ -46,6 +50,7 @@ let AddItemStoryTitle = React.createClass({
             <input className={classes}
                         type="text"
                         name={attr}
+                        ref={attr + 'Input'}
                  placeholder={attr.placeholder}
                  valueLink={this.props[attr]} />
           </div>

--- a/app/views/components/add-item/title.js
+++ b/app/views/components/add-item/title.js
@@ -7,6 +7,10 @@ let AddItemTitle = React.createClass({
     validation: React.PropTypes.object.isRequired
   },
 
+  componentDidMount() {
+    React.findDOMNode(this.refs.titleInput).focus();
+  },
+
   render() {
     var classes = classNames({
       "form-group": true,
@@ -15,7 +19,11 @@ let AddItemTitle = React.createClass({
 
     return (
       <div className={classes}>
-        <input className="form-control" placeholder="What is it?" name="title" valueLink={this.props.title}/>
+        <input className="form-control"
+          placeholder="What is it?"
+          name="title"
+          ref="titleInput"
+          valueLink={this.props.title} />
       </div>
     );
   }

--- a/public/less/components/product-selector.less
+++ b/public/less/components/product-selector.less
@@ -4,6 +4,12 @@
 
 .product-selector .btn {
   margin-top: 1em;
+
+  a {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
 }
 
 .product__tout {


### PR DESCRIPTION
#### What's this PR do?
Fixes some minor issues around the Add Item Modal: adding hotkey support for Cmd+Return for rapid item creation; adds focus to the first input field on modal render and on tab change; restores error handling on item add promise; and fixes broken form validation. Also includes a fix for styling bug on the product selector page (truncating long product names).

#### Where should the reviewer start?
add-item-modal.js

#### How should this be manually tested?
Load up local instance and verify that you are able to create items in succession using Cmd+Enter. Focus should always be returned to the first input ('who' for story; title for all other types). Verify that submitting an item without filling in required fields causes error-state highlighting on those fields ('who', 'what', 'where' in story; 'title' in all else). You should still be able to close a partially filled-out add item form and reopen the form with that entered data still present.

#### Any background context you want to provide?
Nope

#### What ticket or issue # does this fix?
Fixes #212

#### Screenshots (if appropriate)
Product selector page style bug:
![screen shot 2015-07-21 at 11 43 04 am](https://cloud.githubusercontent.com/assets/1137259/8815276/b38088de-2fcb-11e5-8304-212b387c3d96.png)

#### What gif best describes this PR or how it makes you feel?
![200](https://cloud.githubusercontent.com/assets/1137259/8815301/04df2fc8-2fcc-11e5-86f9-8d901f064309.gif)

#### Definition of Done:
- [ ] Does this contain breaking changes?
- [ ] Did you bump the version number accordingly?
- [ ] Is there appropriate test coverage?
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Did you update the documentation per these changes?