### PR TITLE
Use runtime configuration for javascript

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1,7 +1,10 @@
 /*eslint-env node */
-export const CHANNEL_PREFIX = process.env.NODE_ENV === 'production' ?
-  'api-product_sprintly-aws' : 'api-product_sprintly-development-justinlilly';
 
-export const BASE_URL = process.env.NODE_ENV === 'production' ? 'https://sprint.ly' : 'https://local.sprint.ly:9000';
+if (typeof __manifold_config !== "object") {
+  throw new Error("__manifold_config is missing!");
+}
 
-export const PUSHER_KEY = process.env.PUSHER_KEY || '';
+export default __manifold_config;
+export const BASE_URL = __manifold_config.BASE_URL;
+export const PUSHER_KEY = __manifold_config.PUSHER_KEY;
+export const CHANNEL_PREFIX = __manifold_config.CHANNEL_PREFIX;

--- a/app/config.js
+++ b/app/config.js
@@ -1,7 +1,8 @@
 /*eslint-env node */
 
 if (typeof __manifold_config !== "object") {
-  throw new Error("__manifold_config is missing!");
+  console.warn("__manifold_config is missing!");
+  var __manifold_config = {};
 }
 
 export default __manifold_config;

--- a/config/default.js
+++ b/config/default.js
@@ -4,3 +4,5 @@ exports.client_secret = process.env.SPRINTLY_CLIENT_SECRET || '';
 exports.cookie_password = process.env.COOKIE_PASSWORD || 'shhh';
 exports.forceHttps = process.env.FORCE_HTTPS || true;
 exports.redirect_uri = 'http://local.sprint.ly:3600'
+exports.pusher_key = process.env.PUSHER_KEY || '';
+exports.channel_prefix = process.env.CHANNEL_PREFIX || '';

--- a/config/production.js
+++ b/config/production.js
@@ -1,2 +1,3 @@
 exports.sprintly_api_root = 'https://sprint.ly';
 exports.redirect_uri = process.env.REDIRECT_URI || 'https://sprintly-manifold.herokuapp.com'
+exports.channel_prefix = 'api-product_sprintly-aws';

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "scripts": {
     "dev": "gulp dev",
-    "build": "BASE_URL=https://local.sprint.ly:9000/api browserify app -d | exorcist -b './app' public/js/manifold.js.map > public/js/manifold.js",
+    "build": "browserify app -d | exorcist -b './app' public/js/manifold.js.map > public/js/manifold.js",
     "build-less": "gulp less",
     "build-production": "npm run build-production-js && npm run build-production-css",
     "build-production-css": "gulp css",
@@ -66,7 +66,7 @@
     "start": "node server.js",
     "test": "NODE_ENV=test ./node_modules/karma/bin/karma start --browsers Firefox --single-run",
     "watch-test": "NODE_ENV=test ./node_modules/karma/bin/karma start",
-    "watchify": "BASE_URL=https://local.sprint.ly:9000/api watchify app -d -v -o 'exorcist -b './app' public/js/manifold.js.map > public/js/manifold.js'",
+    "watchify": "watchify app -d -v -o 'exorcist -b './app' public/js/manifold.js.map > public/js/manifold.js'",
     "watchify-test": "NODE_ENV=test watchify test/index.js -o 'exorcist -b './app' test/test-bundle.js.map > test/test-bundle.js' -t rewireify -t babelify -t envify -dv"
   },
   "browserify": {

--- a/server.js
+++ b/server.js
@@ -41,6 +41,7 @@ server.register([
 
 function serveApp(request, reply) {
   reply.view('layout.html', {
+    config: config,
     token: request.auth.credentials.token
   })
 }

--- a/views/layout.html
+++ b/views/layout.html
@@ -23,7 +23,15 @@
     <div id="manifold" class="row-offcanvas row-offcanvas-left"></div>
 
     <script>
-      var __token = '{{token}}';
+      {% autoescape false %}
+      var __token = {{ token | json }};
+      var __sprintly_data_config = {{ { BASE_URL: config.sprintly_api_root + "/api" } | json }};
+      var __manifold_config = {{ {
+        BASE_URL: config.sprintly_api_root,
+        PUSHER_KEY: config.pusher_key,
+        CHANNEL_PREFIX: config.channel_prefix
+      } | json }};
+      {% endautoescape %}
     </script>
 
     <script src="//js.pusher.com/2.2/pusher.min.js"></script>


### PR DESCRIPTION
NOTE: There is a related sprintly-data change. See https://github.com/sprintly/sprintly-data/pull/18

#### What's this PR do?

Removes javascript build time configuration in favor of run-time configuration via variables.

#### Where should the reviewer start?

See `app/config.js` and `views/layout.html`.

#### How should this be manually tested?

Verify that configuration can be changed WITHOUT rebuild by updating `config/local.js` and restarting server.

#### Any background context you want to provide?
#### What are the relevant tickets?

https://sprint.ly/product/31528/item/430