### PR TITLE
Add correct dependencies to gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,15 +18,15 @@ function run(command) {
 }
 
 gulp.task('less', function() {
-  gulp.src('public/less/main.less')
+  return gulp.src('public/less/main.less')
     .pipe(sourcemaps.init())
     .pipe(less())
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('public/css'));
 });
 
-gulp.task('cssmin', function() {
-  gulp.src('public/css/main.css')
+gulp.task('cssmin', ['less'], function() {
+  return gulp.src('public/css/main.css')
     .pipe(csso())
     .pipe(rename({
       suffix: '.min'


### PR DESCRIPTION
#### What's this PR do?

Add's correct dependencies to gulp-file to prevent race condition in production css build (the cssmin step previously wouldn't wait for the less build to finish).

#### Any background context you want to provide?

We should get rid of gulp, until then it should at least be correct.
