### PR TITLE
383-everything-filter-clear

### DIFF
--- a/app/views/components/filters/filters-menu.js
+++ b/app/views/components/filters/filters-menu.js
@@ -1,20 +1,12 @@
 import _ from 'lodash'
 import React from 'react/addons'
 import MembersFilter from './forms/members-filter'
+import MyItems from './forms/my-items'
 import CheckboxFilter from './forms/checkbox-filter'
 import TagsFilter from './forms/tags-filter'
 import classNames from 'classnames'
 import onClickOutside from '@sprintly/react-onclickoutside'
 import FilterActions from '../../../actions/filter-actions'
-
-let MyItems = React.createClass({
-  render() {
-    let labelText = this.props.active ? 'Everything' : 'My Items'
-    return (
-      <a href="#" onClick={this.props.onClick} className="filters-menu__mine">{labelText}</a>
-    )
-  }
-})
 
 let FiltersMenu = React.createClass({
 

--- a/app/views/components/filters/forms/my-items-test.js
+++ b/app/views/components/filters/forms/my-items-test.js
@@ -1,0 +1,71 @@
+/* eslint-env mocha, node */
+var assert = require('chai').assert
+var React = require('react/addons')
+var TestUtils = React.addons.TestUtils
+var MyItems = require('./my-items')
+var sinon = require('sinon')
+
+let FilterActions = MyItems.__get__('FilterActions')
+
+describe('MyItems', function() {
+  beforeEach(function() {
+    this.sinon = sinon.sandbox.create()
+  })
+
+  afterEach(function() {
+    this.sinon.restore()
+  })
+
+  describe('is Active', function() {
+    beforeEach(function() {
+      this.clearHandler = this.sinon.stub(FilterActions, 'clear')
+
+      let props = {
+        active: true
+      }
+
+      let component = TestUtils.renderIntoDocument(<MyItems {...props} />)
+      this.mineLink = TestUtils.findRenderedDOMComponentWithClass(component, 'filters-menu__mine').getDOMNode()
+    })
+
+    it('is labeled \'Everything\'', function() {
+      let target = 'Everything'
+      let result = this.mineLink.text
+
+      assert.equal(result, target)
+    })
+
+    it('triggers a filter clear', function() {
+      TestUtils.Simulate.click(this.mineLink)
+
+      assert.isTrue(this.clearHandler.calledOnce)
+    })
+  })
+
+  describe('is inactive', function() {
+    beforeEach(function() {
+      this.clickHandler = this.sinon.stub()
+
+      let props = {
+        active: false,
+        onClick: this.clickHandler
+      }
+
+      let component = TestUtils.renderIntoDocument(<MyItems {...props} />)
+      this.mineLink = TestUtils.findRenderedDOMComponentWithClass(component, 'filters-menu__mine').getDOMNode()
+    })
+
+    it('is labeled \'My Items\'', function() {
+      let target = 'My Items'
+      let result = this.mineLink.text
+
+      assert.equal(result, target)
+    })
+
+    it('triggers the click handler prop', function() {
+      TestUtils.Simulate.click(this.mineLink)
+
+      assert.isTrue(this.clickHandler.calledOnce)
+    })
+  })
+})

--- a/app/views/components/filters/forms/my-items.js
+++ b/app/views/components/filters/forms/my-items.js
@@ -1,0 +1,20 @@
+import React from 'react/addons'
+import FilterActions from '../../../../actions/filter-actions';
+
+let MyItems = React.createClass({
+
+  propTypes: {
+    active: React.PropTypes.bool
+  },
+
+  render() {
+    let labelText = this.props.active ? 'Everything' : 'My Items';
+    let clickHander = this.props.active ? FilterActions.clear : this.props.onClick;
+
+    return (
+      <a href="#" onClick={clickHander} className="filters-menu__mine">{labelText}</a>
+    )
+  }
+})
+
+export default MyItems

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ require("../app/stores/product-store-test.js");
 require("../app/stores/sidebar-store-test.js");
 require("../app/views/components/filters/filter-component-test.js");
 require("../app/views/components/filters/forms/members-filter-test.js");
+require("../app/views/components/filters/forms/my-items-test.js");
 require("../app/views/components/filters/velocity-component-test.js");
 require("../app/views/components/header-test.js");
 require("../app/views/components/helpers-test.js");


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug where:
* When filters were applied
* I expect that by clicking `Everything` that all the filters would be cleared
* Instead they were being filtered by assigned to me

Now `Everything` === `Clear Filters` & correctly clears the filters

#### Where should the reviewer start?
`components/filters/forms/my-items.js`

#### How should this be manually tested?
Create a filter on the kanban board
See the adjacent button text become `Clear Filters`
Clicking that should clear all filters

#### What are the relevant tickets?
[383](https://kanban.sprint.ly/product/31528/item/383)

#### Screenshots (if appropriate)
![](http://g.recordit.co/dDr90fDRHY.gif)